### PR TITLE
fix: if `pullRequest.mergeCommit` is falsy, use `commit` for sha and url

### DIFF
--- a/lib/get-all-commits-for-file.js
+++ b/lib/get-all-commits-for-file.js
@@ -99,6 +99,9 @@ export async function getAllCommitsForFile(
   const [query, parameters] = sha
     ? [queryFromCommit, { owner, repo, path, since, sha }]
     : [queryDefaultBranch, { owner, repo, path, since }];
+
+  console.log(query);
+  console.log(JSON.stringify(parameters, null, 2));
   const result = await octokit.graphql.paginate(query, parameters);
 
   const defaultBranchName = result.repository.defaultBranchRef.name;
@@ -115,11 +118,14 @@ export async function getAllCommitsForFile(
     const [pullRequest] = commit.associatedPullRequests.nodes.filter(
       (pullRequest) => pullRequest.baseRef?.name === defaultBranchName
     );
+
     const { createdAt, sha, url, pullRequestUrl } = pullRequest
       ? {
           createdAt: pullRequest.mergedAt,
-          sha: pullRequest.mergeCommit.oid,
-          url: pullRequest.mergeCommit.url,
+          // there are cases where pull request is set but pullRequest.mergeCommit is not, e.g.
+          // https://github.com/gr2m/all-contributors-import/issues/4#issuecomment-1620459938
+          sha: (pullRequest.mergeCommit || commit).oid,
+          url: (pullRequest.mergeCommit || commit).url,
           pullRequestUrl: pullRequest.url,
         }
       : {


### PR DESCRIPTION
closes #4